### PR TITLE
Allow rovers and miners to fail, add "resource" idea that is produced from ground, fix them

### DIFF
--- a/Assets/Scenes/LunarLandscape3D.unity
+++ b/Assets/Scenes/LunarLandscape3D.unity
@@ -412,6 +412,7 @@ MonoBehaviour:
   spawn_radius: 10
   time_scale: 5
   udp_socket: {fileID: 298185384}
+  totalResources: 1000
 --- !u!114 &298185384
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -544,6 +545,10 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3730126799291413820, guid: e6f7af778f76c4793ba4bb20ee60a733, type: 3}
+      propertyPath: resourcesPerScoop
+      value: 20
+      objectReference: {fileID: 0}
     - target: {fileID: 5733824024454097481, guid: e6f7af778f76c4793ba4bb20ee60a733, type: 3}
       propertyPath: m_LocalPosition.x
       value: -13.36
@@ -624,6 +629,10 @@ PrefabInstance:
     - target: {fileID: 3730126799291413820, guid: e6f7af778f76c4793ba4bb20ee60a733, type: 3}
       propertyPath: m_Enabled
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3730126799291413820, guid: e6f7af778f76c4793ba4bb20ee60a733, type: 3}
+      propertyPath: resourcesPerScoop
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 5733824024454097481, guid: e6f7af778f76c4793ba4bb20ee60a733, type: 3}
       propertyPath: m_LocalPosition.x
@@ -821,6 +830,10 @@ PrefabInstance:
     - target: {fileID: 3730126799291413820, guid: e6f7af778f76c4793ba4bb20ee60a733, type: 3}
       propertyPath: m_Enabled
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3730126799291413820, guid: e6f7af778f76c4793ba4bb20ee60a733, type: 3}
+      propertyPath: resourcesPerScoop
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 5733824024454097481, guid: e6f7af778f76c4793ba4bb20ee60a733, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/GameAgent.cs
+++ b/Assets/Scripts/GameAgent.cs
@@ -3,11 +3,57 @@ using System.Collections;
 using System.Collections.Generic;
 using RVO;
 using UnityEngine;
-using Random = System.Random;
 
 using RStateType = RoverNode.State;
 
-public class GameAgent : MonoBehaviour
+public class FailableModule : MonoBehaviour {
+  public float maybeFailFreq = 100f;
+  public float failureChance = 0.01f;
+  public Vector3 realCenter;
+  public float materialsToRepair = 500f;
+
+  public float neededMaterials = -1;
+
+  void Start() {
+    // jank
+    realCenter = GetComponentsInChildren<Renderer>()[0].bounds.center;
+    StartCoroutine(failLoop());
+  }
+
+  public void repair(float materials) {
+    Debug.Assert(neededMaterials >= 0);
+    neededMaterials -= materials;
+    if (neededMaterials <= 0f) {
+      registerFixed();
+      fix();
+    }
+  }
+
+  public virtual void fail() { Debug.Assert(false); }
+  public virtual void fix() { Debug.Assert(false); }
+
+  void registerBroken() {
+    SingletonBehaviour<GameMainManager>.Instance.brokenModules.Add(this, false);
+  }
+
+  void registerFixed() {
+    SingletonBehaviour<GameMainManager>.Instance.brokenModules.Remove(this);
+  }
+
+  IEnumerator failLoop() {
+    while (true) {
+      if (UnityEngine.Random.Range(0f, 1f) <= failureChance) {
+        registerBroken();
+        neededMaterials = materialsToRepair;
+        fail();
+      }
+
+      yield return new WaitForSeconds(maybeFailFreq);
+    }
+  }
+};
+
+public class GameAgent : FailableModule
 {
     [HideInInspector] public int sid = -1;
 
@@ -40,14 +86,18 @@ public class GameAgent : MonoBehaviour
     private float target_angular_velocity = 0f;
 
     public float lowBattery = 20f;
+    public float carryableResources = 100f;
+    public float repairDowntimeS = 100f;
 
     private static Dictionary<RStateType, RoverState.Activity> activityMap =
       new Dictionary<RStateType, RoverState.Activity>{
         {RStateType.MOVING_TO_MINE, RoverState.Activity.MOVING},
         {RStateType.MOVING_TO_PROCESSING, RoverState.Activity.MOVING},
         {RStateType.MOVING_TO_CHARGING, RoverState.Activity.MOVING},
+        {RStateType.MOVING_TO_REPAIRING, RoverState.Activity.MOVING},
         {RStateType.MINING, RoverState.Activity.MINING},
         {RStateType.CHARGING, RoverState.Activity.CHARGING},
+        {RStateType.REPAIRING, RoverState.Activity.REPAIRING},
         {RStateType.PROCESSING, RoverState.Activity.NEUTRAL},
         {RStateType.OTHER, RoverState.Activity.NEUTRAL}
       };
@@ -56,6 +106,9 @@ public class GameAgent : MonoBehaviour
     public TargetPlanner target_planner;
 
     private Miner? loadingMiner = null;
+    private FailableModule? repairTarget = null;
+
+    private bool broken = false;
 
     void Start()
     {
@@ -65,6 +118,19 @@ public class GameAgent : MonoBehaviour
 
         target_planner = new TargetPlanner(sid);
         motion_planner = new MotionPlanner(sid, transform);
+    }
+
+    public override void fail() {
+      broken = true;
+
+      // Stop us
+      Velocity zero_velocity = new Velocity(0, 0);
+      updateWheels(zero_velocity);
+      Simulator.Instance.setAgentVelocity(sid, Vector2.zero);
+      Simulator.Instance.setAgentIsMoving(sid, false);
+    }
+    public override void fix() {
+      broken = false;
     }
 
     private void initTargetPlanner()
@@ -130,7 +196,8 @@ public class GameAgent : MonoBehaviour
     void updateMinerState(bool isMoving) {
       if (isMoving) {
         if (loadingMiner != null) {
-          loadingMiner.UnregisterRover(bucket);
+          float loadedResources = loadingMiner.UnregisterRover(bucket);
+          SingletonBehaviour<GameMainManager>.Instance.totalResources += loadedResources;
           loadingMiner = null;
         }
         return;
@@ -151,10 +218,43 @@ public class GameAgent : MonoBehaviour
       loadingMiner.RegisterRover(bucket);
     }
 
+    void maybeStartRepairPlan() {
+      foreach (var kvp in SingletonBehaviour<GameMainManager>.Instance.brokenModules) {
+        if (!kvp.Value) {
+          // there has got to be a better way
+          SingletonBehaviour<GameMainManager>.Instance.brokenModules[kvp.Key] = true;
+          target_planner.generateRepairPlan(kvp.Key, repairDowntimeS);
+          repairTarget = kvp.Key;
+          break;
+        }
+      }
+    }
+
+    void updateRepairState() {
+      if (!target_planner.isRepairPlan() || target_planner.getIsMoving() || repairTarget is null) {
+        return;
+      }
+  
+      if ((repairTarget.realCenter - transform.position).magnitude <= 3) {
+        float resources = Mathf.Min(SingletonBehaviour<GameMainManager>.Instance.totalResources, carryableResources);
+        Debug.LogFormat("Repaired with {0} resources", resources);
+        SingletonBehaviour<GameMainManager>.Instance.totalResources -= resources;
+        repairTarget.repair(resources);
+        repairTarget = null;
+      }
+    }
+
     void Update()
     {
+        // Do nothing if we are broken
+        if (broken)
+          return;
+
         if (rover_state.battery.chargeAmount <= lowBattery && !target_planner.isChargePlan()) {
           target_planner.generateChargingPlan(rover_state.battery.chargeDuration());
+        }
+        if (!target_planner.isChargePlan()) {
+          maybeStartRepairPlan();
         }
 
         target_planner.step(get2dPosition());
@@ -173,6 +273,7 @@ public class GameAgent : MonoBehaviour
             Simulator.Instance.setAgentIsMoving(sid, false);
         }
         updateMinerState(target_planner.getIsMoving());
+        updateRepairState();
         if(target_planner.isValidState())
             updateRoverState(target_planner.getCurrentState());
     }

--- a/Assets/Scripts/GameAgent.cs
+++ b/Assets/Scripts/GameAgent.cs
@@ -248,7 +248,10 @@ public class GameAgent : FailableModule
         return;
       }
 
-      SingletonBehaviour<GameMainManager>.Instance.brokenModules[repairTarget] = false;
+      var dict = SingletonBehaviour<GameMainManager>.Instance.brokenModules;
+      if (dict.ContainsKey(repairTarget)) {
+        dict[repairTarget] = false;
+      }
       repairTarget = null;
     }
 

--- a/Assets/Scripts/GameMainManager.cs
+++ b/Assets/Scripts/GameMainManager.cs
@@ -30,6 +30,9 @@ public class GameMainManager : SingletonBehaviour<GameMainManager>
 
     GameAgent[] rovers;
 
+    public Dictionary<FailableModule, bool> brokenModules;
+    public float totalResources = 0.0f;
+
     void Start()
     {
         Time.timeScale = time_scale;
@@ -38,6 +41,10 @@ public class GameMainManager : SingletonBehaviour<GameMainManager>
         Simulator.Instance.setAgentDefaults(10.0f, 10, 5.0f, 5.0f, 1.5f, 2.0f, new Vector2(0.0f, 0.0f));
 
         rovers = RoverSpawner.spawnRovers(agentPrefab, spawn_radius, n_rovers);
+
+        // Maps broken module to rover currently repairing it
+        brokenModules = new Dictionary<FailableModule, bool>();
+
         // jank
         foreach (var rover in rovers)
           foreach (var miner in miners)

--- a/Assets/Scripts/GameMainManager.cs
+++ b/Assets/Scripts/GameMainManager.cs
@@ -1,6 +1,7 @@
 ﻿#define USE_PLANNER
 
 using System;
+using System.IO;
 using System.Collections;
 using System.Collections.Generic;
 using RVO;
@@ -33,9 +34,13 @@ public class GameMainManager : SingletonBehaviour<GameMainManager>
     public Dictionary<FailableModule, bool> brokenModules;
     public float totalResources = 1000.0f; // roughly grams??
 
+    private StreamWriter csvWriter;
+
     void Start()
     {
         Time.timeScale = time_scale;
+
+        csvWriter = new StreamWriter("resourceData.csv", true);
 
         Simulator.Instance.setTimeStep(0.25f);
         Simulator.Instance.setAgentDefaults(10.0f, 10, 5.0f, 5.0f, 1.5f, 2.0f, new Vector2(0.0f, 0.0f));
@@ -50,10 +55,22 @@ public class GameMainManager : SingletonBehaviour<GameMainManager>
           foreach (var miner in miners)
             rover.miners.Add(miner);
 
+        StartCoroutine(logResource());
+
 #if USE_PLANNER
         udp_socket.OnPlannerInput += ProcessPlannerInput;
         StartCoroutine(sendStateToPlanner());
 #endif
+    }
+
+    IEnumerator logResource()
+    {
+        while(true)
+        {
+            csvWriter.WriteLine(totalResources.ToString());
+            csvWriter.Flush();
+            yield return new WaitForSeconds(60f);
+        }
     }
 
     IEnumerator sendStateToPlanner()

--- a/Assets/Scripts/GameMainManager.cs
+++ b/Assets/Scripts/GameMainManager.cs
@@ -31,7 +31,7 @@ public class GameMainManager : SingletonBehaviour<GameMainManager>
     GameAgent[] rovers;
 
     public Dictionary<FailableModule, bool> brokenModules;
-    public float totalResources = 0.0f;
+    public float totalResources = 1000.0f; // roughly grams??
 
     void Start()
     {

--- a/Assets/Scripts/Miner.cs
+++ b/Assets/Scripts/Miner.cs
@@ -22,8 +22,10 @@ public class Miner : FailableModule {
   bool broken = false;
 
   void Start() {
+    initFailable();
     waitingRovers = new List<Transform>();
     status = new IKStatus(GetComponent<InverseKinematics>());
+    resourcesLoaded = new Dictionary<Transform, float>();
   }
 
   public bool RegisterRover(Transform container) {

--- a/Assets/Scripts/Miner.cs
+++ b/Assets/Scripts/Miner.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 
-public class Miner : MonoBehaviour {
+public class Miner : FailableModule {
   // Where to scoop froom
   [SerializeField]
   public Transform minePosition;
@@ -10,28 +10,52 @@ public class Miner : MonoBehaviour {
   [SerializeField]
   public Transform center;
 
+  [SerializeField]
+  public float resourcesPerScoop;
+
   private List<Transform> waitingRovers;
   private IKStatus status;
+  private Dictionary<Transform, float> resourcesLoaded;
 
   private Transform? activeLoading;
+
+  bool broken = false;
 
   void Start() {
     waitingRovers = new List<Transform>();
     status = new IKStatus(GetComponent<InverseKinematics>());
   }
 
-  public void RegisterRover(Transform container) {
+  public bool RegisterRover(Transform container) {
+    if (broken)
+      return false;
+
     Debug.LogFormat("{0}, registered: {1}", name, container);
     waitingRovers.Add(container);
+    resourcesLoaded.Add(container, 0.0f);
+    return true;
   }
 
-  public void UnregisterRover(Transform container) {
-    Debug.LogFormat("{0}, unregistered: {1}", name, container);
+  public float UnregisterRover(Transform container) {
     waitingRovers.Remove(container);
+    float totalLoaded;
+    resourcesLoaded.Remove(container, out totalLoaded);
+    Debug.LogFormat("{0}, unregistered: {1} with {2} resources", name, container, totalLoaded);
+    return totalLoaded;
+  }
+
+  public override void fail() {
+    broken = true;
+  }
+  public override void fix() {
+    broken = false;
   }
 
   void Update() {
     bool converged = status.Step();
+
+    if (broken)
+      return;
 
     // The rover left
     if (activeLoading != null && !waitingRovers.Contains(activeLoading)) {
@@ -52,6 +76,7 @@ public class Miner : MonoBehaviour {
 
     // We dropped off a load
     if (converged && activeLoading != null) {
+      resourcesLoaded[activeLoading] += resourcesPerScoop;
       activeLoading = null;
       status.Target(minePosition);
       return;

--- a/Assets/Scripts/RoverNode.cs
+++ b/Assets/Scripts/RoverNode.cs
@@ -6,7 +6,7 @@ using System;
 public class RoverNode
 {
     public enum GoalType { POSITION, DURATION }
-    public enum State { MOVING_TO_MINE, MINING, MOVING_TO_PROCESSING, PROCESSING, MOVING_TO_CHARGING, CHARGING, OTHER };
+    public enum State { MOVING_TO_MINE, MINING, MOVING_TO_PROCESSING, PROCESSING, MOVING_TO_CHARGING, CHARGING, MOVING_TO_REPAIRING, REPAIRING, OTHER };
 
     public State state;
     public Goal goal;

--- a/Assets/Scripts/RoverState.cs
+++ b/Assets/Scripts/RoverState.cs
@@ -6,7 +6,7 @@ using System;
 [Serializable]
 public class RoverState
 {
-    public enum Activity { MINING, MOVING, CHARGING, NEUTRAL };
+    public enum Activity { MINING, MOVING, CHARGING, REPAIRING, NEUTRAL };
     float neutralDischargeRate = 0.1f;
     float miningDischargeRate = 0.0f;
     float movingDischargeRate = 0.1f;
@@ -79,6 +79,9 @@ public class RoverState
       switch (activity) {
         case Activity.CHARGING:
           battery.charge(dt);
+          return;
+        case Activity.REPAIRING:
+          battery.discharge(neutralDischargeRate, dt);
           return;
         case Activity.MINING:
           battery.discharge(neutralDischargeRate + miningDischargeRate, dt);


### PR DESCRIPTION
- Mess with parameters in FailableModule to tune failure/rate resource consumption for repair
- We have a total resources thing in GameMainManager that is updated when we mine
- Mining doesn't work with broken miners
- The amount of resources mined per scoop can be controlled by a field in Miner
- Still need to add better data collection
- Maybe bugs but seems to work ok